### PR TITLE
adding logic for typekind_struct1

### DIFF
--- a/src/z2ui5_cl_http_handler.clas.locals_imp.abap
+++ b/src/z2ui5_cl_http_handler.clas.locals_imp.abap
@@ -327,7 +327,7 @@ CLASS z2ui5_lcl_system_runtime DEFINITION DEFERRED.
 
            CASE lr_attri->type_kind.
 
-             WHEN cl_abap_classdescr=>typekind_struct2.
+             WHEN cl_abap_classdescr=>typekind_struct2 OR cl_abap_classdescr=>typekind_struct1.
 
                data(lt_attri_tmp) = _get_t_attri(
                    io_app = io_app


### PR DESCRIPTION
When using a flat structure for the screen for example:
![image](https://user-images.githubusercontent.com/96750101/222921765-c20dc833-2a97-4a19-9885-e9172f008168.png)
no binding is happening for any of the fields.

I tracked the issue to the method get_t_attri_by_ref in local class z2ui5_lcl_utility of class Z2UI5_CL_HTTP_HANDLER change in the PR, the dynamic parser was only working for cl_abap_classdescr=>typekind_struct2 which is deep structure, but not for cl_abap_classdescr=>typekind_struct1 which is flat structure.