### PR TITLE
Avoid diff for package

### DIFF
--- a/src/00/package.devc.xml
+++ b/src/00/package.devc.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <abapGit version="v1.0.0" serializer="LCL_OBJECT_DEVC" serializer_version="v1.0.0">
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>


### PR DESCRIPTION
Adds BOM to `package.devc.xml` to avoid diff for on-prem

Closes #133

PS: If you need to create an XML for another object, it's best to start with a copy of an existing XML-file and upload it to GH. When you edit it afterwards, the format (BOM) will be retained.